### PR TITLE
Add /alone command plugin

### DIFF
--- a/AloneX/plugins/alone.py
+++ b/AloneX/plugins/alone.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 TheHamkerAlone
+# Licensed under the MIT License.
+# This file is part of AloneXMusic
+# ALONE-CODER
+
+from pyrogram import filters, types
+from AloneX import app
+
+@app.on_message(
+    filters.command("alone")
+    & filters.private
+    & filters.user(6079943111)
+)
+async def alone_command(_, message: types.Message):
+    await message.reply_video(
+        video="https://files.catbox.moe/0n7rlf.mp4",
+        caption="""**[ 🧟 ](https://t.me/XoDrk) нαϲкє𝚍 ву [ 🧟 ](https://t.me/XoDrk)**""",
+        reply_markup=types.InlineKeyboardMarkup(
+            [
+                [
+                    types.InlineKeyboardButton(
+                        "• нαϲкє𝚍 ву  •", url="https://t.me/XoDrk"
+                    )
+                ]
+            ]
+        ),
+    )


### PR DESCRIPTION
This PR adds a new plugin `alone.py` to the `AloneX/plugins` directory. This plugin implements a private command `/alone` for a specific user ID (6079943111).

Key changes:
- Created `AloneX/plugins/alone.py`.
- Implemented `/alone` command using Pyrogram filters.
- Restricted command to private chat and user ID 6079943111.
- Responds with a video and developer credit links.
- Ensured no sensitive credentials (like `BOT_TOKEN` or `MONGO_URL`) are included or exposed.

The change has been verified for syntax and module loading within the bot's framework.

---
*PR created automatically by Jules for task [12449256757326199356](https://jules.google.com/task/12449256757326199356) started by @TheHamkerAlone*