### PR TITLE
fix: resolve JSON parsing error and TypeError in TgCall

### DIFF
--- a/AloneX/core/calls.py
+++ b/AloneX/core/calls.py
@@ -166,20 +166,19 @@ class TgCall(PyTgCalls):
         return round(sum(pings) / len(pings), 2)
 
 
-    async def decorators(self) -> None:
-        for client in self.clients:
-            @client.on_update()
-            async def update_handler(_, update: types.Update) -> None:
-                if isinstance(update, types.StreamEnded):
-                    if update.stream_type == types.StreamEnded.Type.AUDIO:
-                        await self.play_next(update.chat_id)
-                elif isinstance(update, types.ChatUpdate):
-                    if update.status in [
-                        types.ChatUpdate.Status.KICKED,
-                        types.ChatUpdate.Status.LEFT_GROUP,
-                        types.ChatUpdate.Status.CLOSED_VOICE_CHAT,
-                    ]:
-                        await self.stop(update.chat_id)
+    async def decorators(self, client: PyTgCalls) -> None:
+        @client.on_update()
+        async def update_handler(_, update: types.Update) -> None:
+            if isinstance(update, types.StreamEnded):
+                if update.stream_type == types.StreamEnded.Type.AUDIO:
+                    await self.play_next(update.chat_id)
+            elif isinstance(update, types.ChatUpdate):
+                if update.status in [
+                    types.ChatUpdate.Status.KICKED,
+                    types.ChatUpdate.Status.LEFT_GROUP,
+                    types.ChatUpdate.Status.CLOSED_VOICE_CHAT,
+                ]:
+                    await self.stop(update.chat_id)
 
 
     async def boot(self) -> None:


### PR DESCRIPTION
- Fixed AloneX/locales/en.json by removing invalid header comments that caused a JSONDecodeError.
- Fixed AloneX/core/calls.py by updating the TgCall.decorators method signature to correctly accept the client argument, resolving a TypeError.