### PR TITLE
Fix missing configuration attributes in Config class

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,10 @@ class Config:
         self.AUTO_END: bool = getenv("AUTO_END", False)
         self.AUTO_LEAVE: bool = getenv("AUTO_LEAVE", False)
         self.VIDEO_PLAY: bool = getenv("VIDEO_PLAY", True)
+
+        self.QUEUE_LIMIT = int(getenv("QUEUE_LIMIT", "50"))
+        self.DURATION_LIMIT = int(getenv("DURATION_LIMIT", "5400"))
+        self.PLAYLIST_LIMIT = int(getenv("PLAYLIST_LIMIT", "20"))
         self.COOKIES_URL = [
             url for url in getenv("COOKIES_URL", "").split(" ")
             if url and "batbin.me" in url

--- a/sample.env
+++ b/sample.env
@@ -13,3 +13,8 @@ OWNER_ID=
 
 # pyrogram session from @StringFatherBot on telegram
 SESSION=
+
+# limits for the bot
+QUEUE_LIMIT=50
+DURATION_LIMIT=5400
+PLAYLIST_LIMIT=20


### PR DESCRIPTION
Fixed the `AttributeError: 'Config' object has no attribute 'QUEUE_LIMIT'` by adding the missing attributes (`QUEUE_LIMIT`, `DURATION_LIMIT`, and `PLAYLIST_LIMIT`) to the `Config` class in `config.py`. Also updated `sample.env` to include these variables. Verified the fix by checking attribute accessibility in the `Config` object.

---
*PR created automatically by Jules for task [6189534884802432382](https://jules.google.com/task/6189534884802432382) started by @TeamAloneOp*