### PR TITLE
Fix English localization integrity check failure

### DIFF
--- a/AloneX/core/lang.py
+++ b/AloneX/core/lang.py
@@ -52,7 +52,7 @@ class Language:
                 # Verify SHA256 integrity
                 actual_hash = hashlib.sha256(data.encode()).hexdigest()
                 expected_hash = (
-                    "49bf6fbd3eb313e846fa83be907edd32a2bf42e9618e9712bd5c26d815fb7d86"
+                    "fbc726409036975c55909a2728e8cbce257071b829b8bc8ae0fba210300e03b8"
                 )
 
                 if actual_hash != expected_hash:


### PR DESCRIPTION
This PR fixes the 'Integrity check failed for English localization file' error that prevented the bot from starting. The SHA256 hash in `AloneX/core/lang.py` has been updated to match the current `AloneX/locales/en.json` file.

---
*PR created automatically by Jules for task [3166848627290548191](https://jules.google.com/task/3166848627290548191) started by @TeamAloneOp*