### PR TITLE
Update error_no_call message

### DIFF
--- a/AloneX/core/calls.py
+++ b/AloneX/core/calls.py
@@ -109,7 +109,7 @@ class TgCall(PyTgCalls):
             await self.play_next(chat_id)
         except exceptions.NoActiveGroupCall:
             await self.stop(chat_id)
-            await message.edit_text(_lang["error_no_call"])
+            await message.edit_text("No active video chat found.\n\nPlease start one and try again.")
         except exceptions.NoAudioSourceFound:
             await message.edit_text(_lang["error_no_audio"])
             await self.play_next(chat_id)


### PR DESCRIPTION
Hardcodes the "No active video chat found." message directly in core/calls.py exception block as requested for speed.

---
*PR created automatically by Jules for task [13940336695705110381](https://jules.google.com/task/13940336695705110381) started by @TheHamkerAlone*